### PR TITLE
build: fix build issue in konflux

### DIFF
--- a/src/cloud-api-adaptor/podvm/files/etc/kata-opa/default-policy.rego
+++ b/src/cloud-api-adaptor/podvm/files/etc/kata-opa/default-policy.rego
@@ -1,1 +1,0 @@
-/run/peerpod/policy.rego

--- a/src/cloud-api-adaptor/podvm/qcow2/copy-files.sh
+++ b/src/cloud-api-adaptor/podvm/qcow2/copy-files.sh
@@ -30,6 +30,7 @@ sudo cp -a /tmp/files/pause_bundle /
 # Copy the kata-agent OPA policy files
 sudo mkdir -p /etc/kata-opa
 sudo cp -a /tmp/files/etc/kata-opa/* /etc/kata-opa/
+sudo ln -s /run/peerpod/policy.rego /etc/kata-opa/default-policy.rego
 sudo cp -a /tmp/files/etc/tmpfiles.d/policy.conf /etc/tmpfiles.d/
 
 # Copy an empty auth.json for image pulling


### PR DESCRIPTION
The sources contain a symbolic link pointing to /run/[...] This is not accepted by our build policies, which prevents the build.

To fix it, I am removing the symbolic link, and I'm modifying the script that copies this in the podvm image, so that this script now creates the link again in the final image.