### PR TITLE
osc-caa-webhook: enable hermetic build in Konflux

### DIFF
--- a/.tekton/osc-caa-webhook-pull-request.yaml
+++ b/.tekton/osc-caa-webhook-pull-request.yaml
@@ -31,6 +31,8 @@ spec:
     value: Dockerfile
   - name: path-context
     value: src/webhook
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "./src/webhook/"}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -102,7 +104,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string

--- a/.tekton/osc-caa-webhook-push.yaml
+++ b/.tekton/osc-caa-webhook-push.yaml
@@ -29,6 +29,8 @@ spec:
     value: Dockerfile
   - name: path-context
     value: src/webhook
+  - name: prefetch-input
+    value: '{"type": "gomod", "path": "./src/webhook/"}'
   pipelineSpec:
     description: |
       This pipeline is ideal for building container images from a Containerfile while reducing network traffic.
@@ -100,7 +102,7 @@ spec:
       description: Skip checks against built image
       name: skip-checks
       type: string
-    - default: "false"
+    - default: "true"
       description: Execute the build with network isolation
       name: hermetic
       type: string


### PR DESCRIPTION
Setup prefetcher for go dependencies for the webhook image, and enable hermetic builds.

Fixes: [KATA-3826](https://issues.redhat.com//browse/KATA-3826)