### PR TITLE
Build only when required

### DIFF
--- a/.tekton/osc-caa-push.yaml
+++ b/.tekton/osc-caa-push.yaml
@@ -7,7 +7,8 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "osc-release"
+      == "osc-release" && ( "src/***".pathChanged() || ".tekton/osc-caa-push.yaml".pathChanged()
+      )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-caa-webhook-push.yaml
+++ b/.tekton/osc-caa-webhook-push.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "osc-release"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "osc-release" &&
+      ( "src/webhook/***".pathChanged() || ".tekton/osc-caa-webhook-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-podvm-payload-pull-request.yaml
+++ b/.tekton/osc-podvm-payload-pull-request.yaml
@@ -7,8 +7,10 @@ metadata:
     build.appstudio.redhat.com/pull_request_number: '{{pull_request_number}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "osc-release"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "pull_request" &&
+      target_branch == "osc-release" &&
+      ( "podvm-payload/***".pathChanged() || ".tekton/osc-podvm-payload-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-podvm-payload-push.yaml
+++ b/.tekton/osc-podvm-payload-push.yaml
@@ -6,8 +6,10 @@ metadata:
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "osc-release"
+    pipelinesascode.tekton.dev/on-cel-expression: |
+      event == "push" &&
+      target_branch == "osc-release" &&
+      ( "podvm-payload/***".pathChanged() || ".tekton/osc-podvm-payload-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers


### PR DESCRIPTION
The podvm-payload pipeline was triggering on webhook change, so I'm trying to fix it.
Also adding rules to reduce rebuilds on the "push" side, as these trigger updates of the bundle image - if the code didn't change, we don't need a rebuild.