### PR TITLE
Enable all-attesters for x86_64

### DIFF
--- a/podvm-payload/Dockerfile
+++ b/podvm-payload/Dockerfile
@@ -72,7 +72,7 @@ RUN ARCH=$(uname -m) && \
   if [ "$ARCH" = "s390x" ]; then \
         cargo build --verbose --release --no-default-features --features "coco_as,kbs,se-attester,bin,ttrpc,openssl"; \
   else \
-        cargo build --verbose --release --no-default-features --features "coco_as,kbs,az-snp-vtpm-attester,az-tdx-vtpm-attester,bin,ttrpc,openssl"; \
+        cargo build --verbose --release --no-default-features --features "coco_as,kbs,all-attesters,bin,ttrpc,openssl"; \
   fi
 RUN cp /workdir/guest-components/target/release/ttrpc-aa /artifacts/usr/local/bin/attestation-agent
 


### PR DESCRIPTION
Enable snp,tdx attesters in addition to azure vtpm attesters. This will enable remote attestation on GCP and AWS

Fixes: #[KATA-2375](https://issues.redhat.com//browse/KATA-2375)