### PR TITLE
podvm-payload: specify the branch for the submodules

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,8 @@
 [submodule "podvm-payload/kata-containers"]
 	path = podvm-payload/kata-containers
 	url = https://github.com/openshift/kata-containers/
+	branch = osc-release
 [submodule "podvm-payload/guest-components"]
 	path = podvm-payload/guest-components
 	url = https://github.com/openshift/confidential-containers-guest-components/
+	branch = osc-release


### PR DESCRIPTION
We are using the "osc-release" branch from our forks. Specifying it in the submodules helps avoid confusion. Hopefully, this should also make Mintmaker create update PRs everytime we change the referenced branch.