### PR TITLE
osc-caa-webhook: use ubi-minimal for base image

### DIFF
--- a/src/webhook/Dockerfile
+++ b/src/webhook/Dockerfile
@@ -21,7 +21,7 @@ ENV GOFLAGS="-tags=strictfipsruntime"
 
 RUN CGO_ENABLED=1 GOOS=linux GOARCH=$TARGETARCH go build -mod=readonly -a -o manager main.go
 
-FROM registry.access.redhat.com/ubi9/ubi-micro:latest
+FROM registry.access.redhat.com/ubi9/ubi-minimal:9.5
 WORKDIR /
 COPY --from=builder /workspace/manager .
 USER 65532:65532


### PR DESCRIPTION
The upstream Dockerfile was using "distroless", which I translated to "ubi-micro" for our builds. This worked fine, except that the FIPS compliance checks are failing, because "ubi-micro" doesn't have all needed components (e.g: openssl libs).

This commit uses "ubi-minimal" as the base image, as this should be FIPS-compliant.