### PR TITLE
osc-caa: reorganize the on-cel-expression for readability

### DIFF
--- a/.tekton/osc-caa-pull-request.yaml
+++ b/.tekton/osc-caa-pull-request.yaml
@@ -8,9 +8,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "osc-release" && ( "src/***".pathChanged() || ".tekton/osc-caa-pull-request.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
+      target_branch == "osc-release" &&
+      ( "src/***".pathChanged() || ".tekton/osc-caa-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers

--- a/.tekton/osc-caa-push.yaml
+++ b/.tekton/osc-caa-push.yaml
@@ -7,9 +7,9 @@ metadata:
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
-    pipelinesascode.tekton.dev/on-cel-expression: event == "push" && target_branch
-      == "osc-release" && ( "src/***".pathChanged() || ".tekton/osc-caa-push.yaml".pathChanged()
-      )
+    pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
+      target_branch == "osc-release" &&
+      ( "src/***".pathChanged() || ".tekton/osc-caa-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
     appstudio.openshift.io/application: openshift-sandboxed-containers


### PR DESCRIPTION
This is not really needed, but we need a code change that will trigger a rebuild of the osc-caa image...

Rationale is:
- #80 was merged, but didn't trigger the on-push pipeline for osc-caa
- discussion with the Konflux support team revealed that while on-pull pipeline takes all commits in the PR into account to decide what pipeline to trigger, the on-push pipeline only looks at the HEAD commit (see https://issues.redhat.com/browse/SRVKP-7670)
- because of the above, even using a "/retest" comment on the github commit does not trigger osc-caa pipeline (see https://github.com/openshift/cloud-api-adaptor/commit/566d9aa65a4dedf7ca0d8b9e2c531069aa396e46)
- the Konflux console UI has a button for "Start a new build" for a given component, but it doesn't work. This is a known issue, about to be fixed... but not yet.

The bottom line is that we have code in the repo that is ready for building/releasing the osc-caa image... but we have no way to trigger it.

This commit is just an attempt to make that build happen.