### PR TITLE
osc-release-v1.10: update the tekton files with new IDs

### DIFF
--- a/.tekton/osc-caa-pull-request.yaml
+++ b/.tekton/osc-caa-pull-request.yaml
@@ -9,12 +9,12 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
-      target_branch == "osc-release" &&
+      target_branch == "osc-release-v1.10" &&
       ( "src/***".pathChanged() || ".tekton/osc-caa-pull-request.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-caa
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-caa-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-caa-on-pull-request
   namespace: ose-osc-tenant
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-v1-10:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -624,7 +624,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-caa
+    serviceAccountName: build-pipeline-osc-caa-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-caa-push.yaml
+++ b/.tekton/osc-caa-push.yaml
@@ -8,12 +8,12 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
-      target_branch == "osc-release" &&
+      target_branch == "osc-release-v1.10" &&
       ( "src/***".pathChanged() || ".tekton/osc-caa-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-caa
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-caa-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-caa-on-push
   namespace: ose-osc-tenant
@@ -24,7 +24,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-v1-10:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -621,7 +621,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-caa
+    serviceAccountName: build-pipeline-osc-caa-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-caa-webhook-pull-request.yaml
+++ b/.tekton/osc-caa-webhook-pull-request.yaml
@@ -9,12 +9,12 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" && target_branch
-      == "osc-release" && ( "src/webhook/***".pathChanged() || ".tekton/osc-caa-webhook-pull-request.yaml".pathChanged()
+      == "osc-release-v1.10" && ( "src/webhook/***".pathChanged() || ".tekton/osc-caa-webhook-pull-request.yaml".pathChanged()
       )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-caa-webhook
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-caa-webhook-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-caa-webhook-on-pull-request
   namespace: ose-osc-tenant
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook-v1-10:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -620,7 +620,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-caa-webhook
+    serviceAccountName: build-pipeline-osc-caa-webhook-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-caa-webhook-push.yaml
+++ b/.tekton/osc-caa-webhook-push.yaml
@@ -8,11 +8,11 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
-      target_branch == "osc-release" && ( "src/webhook/***".pathChanged() || ".tekton/osc-caa-webhook-push.yaml".pathChanged() )
+      target_branch == "osc-release-v1.10" && ( "src/webhook/***".pathChanged() || ".tekton/osc-caa-webhook-push.yaml".pathChanged() )
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-caa-webhook
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-caa-webhook-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-caa-webhook-on-push
   namespace: ose-osc-tenant
@@ -23,7 +23,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook-v1-10:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -616,7 +616,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-caa-webhook
+    serviceAccountName: build-pipeline-osc-caa-webhook-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-podvm-payload-pull-request.yaml
+++ b/.tekton/osc-podvm-payload-pull-request.yaml
@@ -10,12 +10,12 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "osc-release" &&
+      target_branch == "osc-release-v1.10" &&
       ( "podvm-payload/***".pathChanged() || ".tekton/osc-podvm-payload-pull-request.yaml".pathChanged() || "src/cloud-api-adaptor/podvm/files/***".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-podvm-payload
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-podvm-payload-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-podvm-payload-on-pull-request
   namespace: ose-osc-tenant
@@ -26,7 +26,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-10:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -624,7 +624,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-podvm-payload
+    serviceAccountName: build-pipeline-osc-podvm-payload-v1-10
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-podvm-payload-push.yaml
+++ b/.tekton/osc-podvm-payload-push.yaml
@@ -9,12 +9,12 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "osc-release" &&
+      target_branch == "osc-release-v1.10" &&
       ( "podvm-payload/***".pathChanged() || ".tekton/osc-podvm-payload-push.yaml".pathChanged() || "src/cloud-api-adaptor/podvm/files/***".pathChanged())
   creationTimestamp: null
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-podvm-payload
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
+    appstudio.openshift.io/component: osc-podvm-payload-v1-10
     pipelines.appstudio.openshift.io/type: build
   name: osc-podvm-payload-on-push
   namespace: ose-osc-tenant
@@ -25,7 +25,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-10:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -621,7 +621,7 @@ spec:
     - name: netrc
       optional: true
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-podvm-payload
+    serviceAccountName: build-pipeline-osc-podvm-payload-v1-10
   workspaces:
   - name: git-auth
     secret:


### PR DESCRIPTION
For the pipeline to trigger on the new branch, we need the tekton files to be updated so that they reference the new Konflux object names, branch name, and quay.io image location.