### PR TITLE
konflux: fix the pipeline names for 1.10 branch

### DIFF
--- a/.tekton/osc-caa-pull-request.yaml
+++ b/.tekton/osc-caa-pull-request.yaml
@@ -16,7 +16,7 @@ metadata:
     appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
     appstudio.openshift.io/component: osc-caa-v1-10
     pipelines.appstudio.openshift.io/type: build
-  name: osc-caa-on-pull-request
+  name: osc-caa-v1-10-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:

--- a/.tekton/osc-caa-push.yaml
+++ b/.tekton/osc-caa-push.yaml
@@ -15,7 +15,7 @@ metadata:
     appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
     appstudio.openshift.io/component: osc-caa-v1-10
     pipelines.appstudio.openshift.io/type: build
-  name: osc-caa-on-push
+  name: osc-caa-v1-10-on-push
   namespace: ose-osc-tenant
 spec:
   params:

--- a/.tekton/osc-caa-webhook-pull-request.yaml
+++ b/.tekton/osc-caa-webhook-pull-request.yaml
@@ -16,7 +16,7 @@ metadata:
     appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
     appstudio.openshift.io/component: osc-caa-webhook-v1-10
     pipelines.appstudio.openshift.io/type: build
-  name: osc-caa-webhook-on-pull-request
+  name: osc-caa-webhook-v1-10-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:

--- a/.tekton/osc-caa-webhook-push.yaml
+++ b/.tekton/osc-caa-webhook-push.yaml
@@ -14,7 +14,7 @@ metadata:
     appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
     appstudio.openshift.io/component: osc-caa-webhook-v1-10
     pipelines.appstudio.openshift.io/type: build
-  name: osc-caa-webhook-on-push
+  name: osc-caa-webhook-v1-10-on-push
   namespace: ose-osc-tenant
 spec:
   params:

--- a/.tekton/osc-podvm-payload-pull-request.yaml
+++ b/.tekton/osc-podvm-payload-pull-request.yaml
@@ -17,7 +17,7 @@ metadata:
     appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
     appstudio.openshift.io/component: osc-podvm-payload-v1-10
     pipelines.appstudio.openshift.io/type: build
-  name: osc-podvm-payload-on-pull-request
+  name: osc-podvm-payload-v1-10-on-pull-request
   namespace: ose-osc-tenant
 spec:
   params:

--- a/.tekton/osc-podvm-payload-push.yaml
+++ b/.tekton/osc-podvm-payload-push.yaml
@@ -16,7 +16,7 @@ metadata:
     appstudio.openshift.io/application: openshift-sandboxed-containers-v1-10
     appstudio.openshift.io/component: osc-podvm-payload-v1-10
     pipelines.appstudio.openshift.io/type: build
-  name: osc-podvm-payload-on-push
+  name: osc-podvm-payload-v1-10-on-push
   namespace: ose-osc-tenant
 spec:
   params:


### PR DESCRIPTION
The pipeline name need to match the component's name.