### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for osc-podvm-payload

### DIFF
--- a/podvm-payload/Dockerfile
+++ b/podvm-payload/Dockerfile
@@ -126,7 +126,8 @@ RUN tar czvf /podvm-binaries.tar.gz -C /artifacts usr/ etc/ && \
 COPY --from=pause_builder /pause-bundle.tar.gz /pause-bundle.tar.gz
 
 # Red Hat labels
-LABEL name="openshift-sandboxed-containers-podvm-payload" \
+LABEL name="openshift-sandboxed-containers/osc-podvm-payload-rhel9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.10::el9" \
 version="1.10.1" \
 com.redhat.component="osc-podvm-payload-container" \
 summary="Container image containing podvm artefacts that is required for creating Pod VM images" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
