### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for osc-caa and osc-caa-webhook

### DIFF
--- a/src/cloud-api-adaptor/Dockerfile.openshift
+++ b/src/cloud-api-adaptor/Dockerfile.openshift
@@ -107,7 +107,8 @@ FROM base-${BUILD_TYPE}
 COPY --from=builder /work/cloud-api-adaptor/cloud-api-adaptor /work/cloud-api-adaptor/entrypoint.sh /usr/local/bin/
 
 # Red Hat labels
-LABEL name="openshift-sandboxed-containers-operator-cloud-api-adaptor" \
+LABEL name="openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.10::el9" \
 version="1.10.1" \
 com.redhat.component="osc-cloud-api-adaptor-container" \
 summary="osc-cloud-api-adaptor provides the ability to create Kata PODs using cloud provider APIs" \

--- a/src/webhook/Dockerfile
+++ b/src/webhook/Dockerfile
@@ -27,7 +27,8 @@ COPY --from=builder /workspace/manager .
 USER 65532:65532
 
 # Red Hat labels
-LABEL name="openshift-sandboxed-containers-operator-cloud-api-adaptor-webhook" \
+LABEL name="openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.10::el9" \
 version="1.10.1" \
 com.redhat.component="osc-cloud-api-adaptor-webhook-container" \
 summary="This mutating webhook modifies a POD spec using specific runtimeclass to remove all resources entries and replace it with peer-pod extended resource." \


### PR DESCRIPTION

For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149