### PR TITLE
azure: Use Premium SSD for improved disk performance

### DIFF
--- a/src/cloud-providers/azure/provider.go
+++ b/src/cloud-providers/azure/provider.go
@@ -386,7 +386,7 @@ func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig stri
 	var securityProfile *armcompute.SecurityProfile
 	if !p.serviceConfig.DisableCVM {
 		managedDiskParams = &armcompute.ManagedDiskParameters{
-			StorageAccountType: to.Ptr(armcompute.StorageAccountTypesStandardLRS),
+			StorageAccountType: to.Ptr(armcompute.StorageAccountTypesPremiumLRS),
 			SecurityProfile: &armcompute.VMDiskSecurityProfile{
 				SecurityEncryptionType: to.Ptr(armcompute.SecurityEncryptionTypesVMGuestStateOnly),
 			},
@@ -401,7 +401,7 @@ func (p *azureProvider) getVMParameters(instanceSize, diskName, cloudConfig stri
 		}
 	} else {
 		managedDiskParams = &armcompute.ManagedDiskParameters{
-			StorageAccountType: to.Ptr(armcompute.StorageAccountTypesStandardLRS),
+			StorageAccountType: to.Ptr(armcompute.StorageAccountTypesPremiumLRS),
 		}
 
 		securityProfile = nil


### PR DESCRIPTION
Change the storage account type from StandardLRS to PremiumLRS for both CVM and non-CVM Azure VMs to improve disk I/O performance. Experiments shows this change may reduce boot times from 1-4 minutes to under 1 minute in certain cases.

