### PR TITLE
Update UBI references to 10.1

### DIFF
--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_binaries.rhel
@@ -40,6 +40,6 @@ RUN LIBC=gnu make binaries
 RUN tar czvf /podvm-binaries.tar.gz -C /src/cloud-api-adaptor/podvm/files usr/ etc/
 RUN tar czvf /pause-bundle.tar.gz -C /src/cloud-api-adaptor/podvm/files pause_bundle/
 
-FROM registry.access.redhat.com/ubi9/ubi:9.4
+FROM registry.access.redhat.com/ubi10/ubi:10.1-1762189261
 COPY --from=podvm_builder /podvm-binaries.tar.gz /
 COPY --from=podvm_builder /pause-bundle.tar.gz /

--- a/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
+++ b/src/cloud-api-adaptor/podvm/Dockerfile.podvm_builder.rhel
@@ -6,7 +6,7 @@
 # Creates a builder container image that should be used to build the Pod VM
 # disk inside a container.
 #
-FROM registry.access.redhat.com/ubi9/ubi:9.4
+FROM registry.access.redhat.com/ubi10/ubi:10.1-1762189261
 
 ARG ARCH="x86_64"
 ARG GO_ARCH="amd64"


### PR DESCRIPTION
This commit updates ubi references from 9.4 to 10.1-1762189261.

Issue: https://issues.redhat.com/browse/KATA-4311