### PR TITLE
osc-podvm-payload: modify the nudge rules to update the initrd build arg file

### DIFF
--- a/.tekton/osc-podvm-payload-push.yaml
+++ b/.tekton/osc-podvm-payload-push.yaml
@@ -3,6 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cloud-api-adaptor?rev={{revision}}
+    build.appstudio.openshift.io/build-nudge-files: ".*.yaml,.*/containerfiles/initrd-builder/argfile.conf"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"


### PR DESCRIPTION
Using nudge PRs to update our yaml files already work, but our initrd builder container relies on a conf file for its build args. We need to tell Mintmaker to update this file too whenever the podvm-payload image is rebuilt.

We also make sure to keep the default ".*.yaml" rule, otherwise our other nudges will stop working.