### PR TITLE
Replace manual disk cleanup with quick-cleanup

### DIFF
--- a/.github/workflows/e2e_libvirt.yaml
+++ b/.github/workflows/e2e_libvirt.yaml
@@ -75,15 +75,10 @@ jobs:
         run: |
           ./hack/ci-helper.sh rebase-atop-of-the-latest-target-branch
 
-      - name: Remove unnecessary directories to free up space
-        run: |
-          sudo rm -rf /usr/local/.ghcup
-          sudo rm -rf /opt/hostedtoolcache/CodeQL
-          sudo rm -rf /usr/local/lib/android/sdk/ndk
-          sudo rm -rf /usr/share/dotnet
-          sudo rm -rf /opt/ghc
-          sudo rm -rf /usr/local/share/boost
-          sudo rm -rf "$AGENT_TOOLSDIRECTORY"
+      - name: Free up disk space
+        uses: palmsoftware/quick-cleanup@v0
+        with:
+          cleanup-mode: aggressive
 
       - name: Read properties from versions.yaml
         run: |


### PR DESCRIPTION
## Summary

Replace the manual disk cleanup step in the libvirt e2e workflow with the shared [`palmsoftware/quick-cleanup`](https://github.com/palmsoftware/quick-cleanup) GitHub Action.

This consolidates the manual cleanup (rm -rf ghcup, CodeQL, android, dotnet, ghc, boost, AGENT_TOOLSDIRECTORY) into a single maintained action. It also provides automatic Docker storage relocation to the larger `/mnt` partition.

Note: The mid-workflow `docker system prune` after image extraction is intentionally preserved as it serves a different purpose.

## Already in use

`quick-cleanup` is already adopted in production workflows across multiple repos:

- [`crc-org/crc`](https://github.com/crc-org/crc/blob/main/.github/workflows/make-rpm.yml#L19) — CRC (OpenShift Local)
- [`palmsoftware/quick-ocp`](https://github.com/palmsoftware/quick-ocp/blob/main/action.yml#L94) — OpenShift cluster deployment action
- [`palmsoftware/quick-k8s`](https://github.com/palmsoftware/quick-k8s/blob/main/action.yml#L509) — Kubernetes cluster deployment action (KinD/Minikube)

## Related PRs

- https://github.com/crc-org/crc/pull/5145
- https://github.com/openshift/ovn-kubernetes/pull/2983
- https://github.com/openshift-kni/openperouter/pull/159
- https://github.com/openshift/metallb-operator/pull/317
- https://github.com/openshift/prometheus-operator/pull/360
- https://github.com/openshift/cloud-api-adaptor/pull/341
- https://github.com/openshift/topolvm/pull/352
- https://github.com/openshift/velero/pull/471




## Tracking

- [palmsoftware/quick-cleanup#3](https://github.com/palmsoftware/quick-cleanup/issues/3) — Tracking issue
- [CNFCERT-1351](https://issues.redhat.com/browse/CNFCERT-1351) — Jira

## Changes

- Updated `.github/workflows/e2e_libvirt.yaml` — replaced "Remove unnecessary directories" step

## Benefits

- **Less boilerplate** — replaces 9 lines of manual rm -rf commands
- **Docker relocation** — automatically moves Docker storage to `/mnt` (larger partition)
- **Adaptive cleanup** — adjusts intensity based on available space
- **Disk reporting** — built-in before/after `df -h` output
- **Maintained upstream** — cleanup targets updated as runner images change
- **Apache 2.0 licensed**