### PR TITLE
konflux: fix nudge files references

### DIFF
--- a/.tekton/osc-podvm-payload-push.yaml
+++ b/.tekton/osc-podvm-payload-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cloud-api-adaptor?rev={{revision}}
-    build.appstudio.openshift.io/build-nudge-files: ".*.yaml,.*/containerfiles/initrd-builder/argfile.conf"
+    build.appstudio.openshift.io/build-nudge-files: ".*.yaml, .*argfile.conf"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"


### PR DESCRIPTION
The nudge doesn't happen for initrd-builders.
The file that we want to update was listed with its path, based on the root of the repository. But the component has a context path which already mention the subfolder in the repository. I suspect that this is why the nudge is failing.
This commit removes the path from the parameter, hopefully catching the file as needed.

NOTE: unfortunately, there is no way (that I know) of testing this other than merging and seeing if it works.
I will revert this change if the problem still occurs.