### PR TITLE
osc-podvm-payload: fix nudge to dm-verity

### DIFF
--- a/.tekton/osc-podvm-payload-push.yaml
+++ b/.tekton/osc-podvm-payload-push.yaml
@@ -3,7 +3,7 @@ kind: PipelineRun
 metadata:
   annotations:
     build.appstudio.openshift.io/repo: https://github.com/openshift/cloud-api-adaptor?rev={{revision}}
-    build.appstudio.openshift.io/build-nudge-files: ".*.yaml, .*argfile.conf"
+    build.appstudio.openshift.io/build-nudge-files: ".*Dockerfile.*, .*.yaml, .*argfile.conf"
     build.appstudio.redhat.com/commit_sha: '{{revision}}'
     build.appstudio.redhat.com/target_branch: '{{target_branch}}'
     pipelinesascode.tekton.dev/cancel-in-progress: "false"


### PR DESCRIPTION
The modification of the nudge rule is working for the bundle and initrd-builder, but doesn't work for dm-verity.
The reason is because I am listing yaml files and the argfile.conf file, but the default rule is now ignored, and Dockerfiles are not edited. This commit explicitely adds "Dockerfile" to the list to make sure dm-verity is updated when podvm-payload is rebuilt.