### PR TITLE
osc-podvm-payload: fix on-cel-expression for the build pipeline

### DIFF
--- a/.tekton/osc-podvm-payload-pull-request.yaml
+++ b/.tekton/osc-podvm-payload-pull-request.yaml
@@ -13,7 +13,7 @@ metadata:
       target_branch == "osc-release" &&
       ( "podvm-payload/***".pathChanged() ||
         ".tekton/osc-podvm-payload-pull-request.yaml".pathChanged() ||
-        "src/cloud-api-adaptor/podvm/files/***".pathChanged() ||
+        "src/cloud-api-adaptor/***".pathChanged() ||
         ".tekton/build-pipeline.yaml".pathChanged()
       )
   creationTimestamp:

--- a/.tekton/osc-podvm-payload-push.yaml
+++ b/.tekton/osc-podvm-payload-push.yaml
@@ -13,7 +13,7 @@ metadata:
       target_branch == "osc-release" &&
       ( "podvm-payload/***".pathChanged() ||
         ".tekton/osc-podvm-payload-push.yaml".pathChanged() ||
-        "src/cloud-api-adaptor/podvm/files/***".pathChanged() ||
+        "src/cloud-api-adaptor/***".pathChanged() ||
         ".tekton/build-pipeline.yaml".pathChanged()
       )
   creationTimestamp:


### PR DESCRIPTION
We build "agent-protocol-forwarder" from the src/cloud-api-adaptor folder, but we were not monitoring changes in this subfolder - only select files in it. This commit makes sure that any modification to the src/cloud-api-adaptor folder will trigger a build of podvm-payload.