### PR TITLE
osc-podvm-payload: fix the memory request for sast-unicode-check

### DIFF
--- a/.tekton/osc-podvm-payload-pull-request.yaml
+++ b/.tekton/osc-podvm-payload-pull-request.yaml
@@ -62,6 +62,14 @@ spec:
             memory: 4Gi
           limits:
             memory: 4Gi
+  - pipelineTaskName: sast-unicode-check
+    stepSpecs:
+      - name: use-trusted-artifact
+        computeResources:
+          requests:
+            memory: 4Gi
+          limits:
+            memory: 4Gi
   - pipelineTaskName: build-source-image
     stepSpecs:
       - name: use-trusted-artifact

--- a/.tekton/osc-podvm-payload-push.yaml
+++ b/.tekton/osc-podvm-payload-push.yaml
@@ -60,6 +60,14 @@ spec:
             memory: 4Gi
           limits:
             memory: 4Gi
+  - pipelineTaskName: sast-unicode-check
+    stepSpecs:
+      - name: use-trusted-artifact
+        computeResources:
+          requests:
+            memory: 4Gi
+          limits:
+            memory: 4Gi
   - pipelineTaskName: build-source-image
     stepSpecs:
       - name: use-trusted-artifact


### PR DESCRIPTION
This is a follow-up to 25c0d9d1cde90cb60c3d40779ecb721c4295fe93