### PR TITLE
mintmaker: fix ignorepath to keep updating our Dockerfile

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -5,7 +5,7 @@
     ],
     "dockerfile": {
         "ignorePaths": [
-            "src/cloud-api-adaptor/Dockerfile",
+            "src/cloud-api-adaptor/Dockerfile$",
             "**/cloud-api-adaptor/test/**",
             "**/hack/**",
             "**/csi-wrapper/**",


### PR DESCRIPTION
The "ignorepath" in renovate is a regexp. Our goal was to make it ignore the upstream "Dockerfile", but as stated, it was also ignoring our downstream "Dockerfile.openshift".

This commit tries to address it by adding a marker for the end of the string.