### PR TITLE
mintmaker: disable github-action manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,6 +14,9 @@
             "**/podvm/**"
         ]
     },
+    "github-actions": {
+        "enabled": false
+    },
     "gomod": {
         "enabled": false
     },


### PR DESCRIPTION
We are not running github actions on our fork, and updating them would cause conflicts every time we rebase.
Disabling updates for it on this repo.