### PR TITLE
mintmaker: limit Dockerfile updates to the files we use downstream

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -4,14 +4,10 @@
         "https://github.com/konflux-ci/mintmaker/blob/main/config/renovate/renovate.json?raw=true"
     ],
     "dockerfile": {
-        "ignorePaths": [
-            "src/cloud-api-adaptor/Dockerfile$",
-            "**/cloud-api-adaptor/test/**",
-            "**/hack/**",
-            "**/csi-wrapper/**",
-            "**/peerpod-ctrl/**",
-            "**/podvm-mkosi/**",
-            "**/podvm/**"
+        "includePaths": [
+            "src/cloud-api-adaptor/Dockerfile.openshift",
+            "src/webhook/Dockerfile",
+            "podvm-payload/Dockerfile"
         ]
     },
     "github-actions": {


### PR DESCRIPTION
We've tried to ignore Dockerfiles that we don't use downstream, but have trouble configuring it properly, and still get updates for files we want to ignore.

This commit inverts the rule and specifically points Mintmaker to the Dockerfiles we're interested in. Hopefully, it should now update nothing else.

See: https://docs.renovatebot.com/configuration-options/#includepaths