### PR TITLE
mintmaker: disable helmv3 manager

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,9 @@
             "podvm-payload/Dockerfile"
         ]
     },
+    "helmv3": {
+        "enabled": false
+    },
     "github-actions": {
         "enabled": false
     },


### PR DESCRIPTION
We don't use helm charts downstream. Leave them as is to avoid conflicts when rebasing to upstream.