### PR TITLE
podvm-payload: Fix restricted OPA policy

### DIFF
--- a/podvm-payload/osc-agent-policy.rego
+++ b/podvm-payload/osc-agent-policy.rego
@@ -1,5 +1,8 @@
 package agent_policy
 
+import future.keywords.in
+import future.keywords.if
+
 default AddARPNeighborsRequest := true
 default AddSwapRequest := true
 default CloseStdinRequest := true


### PR DESCRIPTION
Current OPA policy is crashing the agent with :

```
--> /etc/kata-opa/default-policy.rego:86:42
   |
86 | allow_copy_file_path(path, regex_suffix) if {
   |                                          ^
warning: `if` will be treated as identifier due to missing `import future.keywords.if`
--> /etc/kata-opa/default-policy.rego:89:17
   |
89 |     some regex1 in policy_data.request_defaults.CopyFileRequest
   |                 ^
warning: `in` will be treated as identifier due to missing `import future.keywords.in`
```

The upstream genpolicy tool adds these lines by default as they are still needed :

https://github.com/kata-containers/kata-containers/blob/main/src/tools/genpolicy/rules.rego#L7

Pick up `if` and `in` that we do use in this file.