### PR TITLE
podvm-payload: Fix OPA policy again

### DIFF
--- a/podvm-payload/osc-agent-policy.rego
+++ b/podvm-payload/osc-agent-policy.rego
@@ -6,7 +6,6 @@ import future.keywords.if
 default AddARPNeighborsRequest := true
 default AddSwapRequest := true
 default CloseStdinRequest := true
-default CopyFileRequest := true
 default CreateSandboxRequest := true
 default DestroySandboxRequest := true
 default GetMetricsRequest := true
@@ -40,6 +39,7 @@ default CreateContainerRequest := true
 default SetPolicyRequest := false
 default ExecProcessRequest := false
 default ReadStreamRequest := false
+default CopyFileRequest := false
 
 #
 # CopyFile filtering to ensure the host can only


### PR DESCRIPTION
The expected logic is to :
1) block `CopyFileRequest` by default
2) unblock it if it passes all the policy checks

46a37c3b14 overlooked 1 obviously.