### PR TITLE
konflux: update the tekton files for building 1.12 from new branch

### DIFF
--- a/.tekton/osc-caa-pull-request.yaml
+++ b/.tekton/osc-caa-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
-      target_branch == "osc-release" &&
+      target_branch == "osc-release-v1.12" &&
       (
         "src/***".pathChanged() ||
         ".tekton/osc-caa-pull-request.yaml".pathChanged() ||
@@ -17,10 +17,10 @@ metadata:
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-caa
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-12
+    appstudio.openshift.io/component: osc-caa-v1-12
     pipelines.appstudio.openshift.io/type: build
-  name: osc-caa-on-pull-request
+  name: osc-caa-on-pull-request-v1-12
   namespace: ose-osc-tenant
 spec:
   params:
@@ -47,7 +47,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-caa
+    serviceAccountName: build-pipeline-osc-caa-v1-12
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-caa-push.yaml
+++ b/.tekton/osc-caa-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
-      target_branch == "osc-release" &&
+      target_branch == "osc-release-v1.12" &&
       (
         "src/***".pathChanged() ||
         ".tekton/osc-caa-push.yaml".pathChanged() ||
@@ -16,10 +16,10 @@ metadata:
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-caa
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-12
+    appstudio.openshift.io/component: osc-caa-v1-12
     pipelines.appstudio.openshift.io/type: build
-  name: osc-caa-on-push
+  name: osc-caa-on-push-v1-12
   namespace: ose-osc-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-v1-12:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -44,7 +44,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-caa
+    serviceAccountName: build-pipeline-osc-caa-v1-12
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-caa-webhook-pull-request.yaml
+++ b/.tekton/osc-caa-webhook-pull-request.yaml
@@ -9,7 +9,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "true"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "pull_request" &&
-      target_branch == "osc-release" &&
+      target_branch == "osc-release-v1.12" &&
       (
         "src/webhook/***".pathChanged() ||
         ".tekton/osc-caa-webhook-pull-request.yaml".pathChanged() ||
@@ -17,10 +17,10 @@ metadata:
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-caa-webhook
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-12
+    appstudio.openshift.io/component: osc-caa-webhook-v1-12
     pipelines.appstudio.openshift.io/type: build
-  name: osc-caa-webhook-on-pull-request
+  name: osc-caa-webhook-on-pull-request-v1-12
   namespace: ose-osc-tenant
 spec:
   params:
@@ -29,7 +29,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook-v1-12:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -45,7 +45,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-caa-webhook
+    serviceAccountName: build-pipeline-osc-caa-webhook-v1-12
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-caa-webhook-push.yaml
+++ b/.tekton/osc-caa-webhook-push.yaml
@@ -8,7 +8,7 @@ metadata:
     pipelinesascode.tekton.dev/cancel-in-progress: "false"
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: event == "push" &&
-      target_branch == "osc-release" &&
+      target_branch == "osc-release-v1.12" &&
       (
         "src/webhook/***".pathChanged() ||
         ".tekton/osc-caa-webhook-push.yaml".pathChanged() ||
@@ -16,10 +16,10 @@ metadata:
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-caa-webhook
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-12
+    appstudio.openshift.io/component: osc-caa-webhook-v1-12
     pipelines.appstudio.openshift.io/type: build
-  name: osc-caa-webhook-on-push
+  name: osc-caa-webhook-on-push-v1-12
   namespace: ose-osc-tenant
 spec:
   params:
@@ -28,7 +28,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-caa-webhook-v1-12:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-caa-webhook
+    serviceAccountName: build-pipeline-osc-caa-webhook-v1-12
   workspaces:
   - name: git-auth
     secret:

--- a/.tekton/osc-podvm-payload-pull-request.yaml
+++ b/.tekton/osc-podvm-payload-pull-request.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "pull_request" &&
-      target_branch == "osc-release" &&
+      target_branch == "osc-release-v1.12" &&
       ( "podvm-payload/***".pathChanged() ||
         ".tekton/osc-podvm-payload-pull-request.yaml".pathChanged() ||
         "src/cloud-api-adaptor/***".pathChanged() ||
@@ -18,10 +18,10 @@ metadata:
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-podvm-payload
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-12
+    appstudio.openshift.io/component: osc-podvm-payload-v1-12
     pipelines.appstudio.openshift.io/type: build
-  name: osc-podvm-payload-on-pull-request
+  name: osc-podvm-payload-on-pull-request-v1-12
   namespace: ose-osc-tenant
 spec:
   params:
@@ -30,7 +30,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload:on-pr-{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-12:on-pr-{{revision}}
   - name: image-expires-after
     value: 5d
   - name: build-platforms
@@ -44,7 +44,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-podvm-payload
+    serviceAccountName: build-pipeline-osc-podvm-payload-v1-12
   taskRunSpecs:
   - pipelineTaskName: sast-snyk-check
     stepSpecs:

--- a/.tekton/osc-podvm-payload-push.yaml
+++ b/.tekton/osc-podvm-payload-push.yaml
@@ -10,7 +10,7 @@ metadata:
     pipelinesascode.tekton.dev/max-keep-runs: "3"
     pipelinesascode.tekton.dev/on-cel-expression: |
       event == "push" &&
-      target_branch == "osc-release" &&
+      target_branch == "osc-release-v1.12" &&
       ( "podvm-payload/***".pathChanged() ||
         ".tekton/osc-podvm-payload-push.yaml".pathChanged() ||
         "src/cloud-api-adaptor/***".pathChanged() ||
@@ -18,10 +18,10 @@ metadata:
       )
   creationTimestamp:
   labels:
-    appstudio.openshift.io/application: openshift-sandboxed-containers
-    appstudio.openshift.io/component: osc-podvm-payload
+    appstudio.openshift.io/application: openshift-sandboxed-containers-v1-12
+    appstudio.openshift.io/component: osc-podvm-payload-v1-12
     pipelines.appstudio.openshift.io/type: build
-  name: osc-podvm-payload-on-push
+  name: osc-podvm-payload-v1-12-on-push
   namespace: ose-osc-tenant
 spec:
   params:
@@ -30,7 +30,7 @@ spec:
   - name: revision
     value: '{{revision}}'
   - name: output-image
-    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload:{{revision}}
+    value: quay.io/redhat-user-workloads/ose-osc-tenant/osc-podvm-payload-v1-12:{{revision}}
   - name: build-platforms
     value:
     - linux/x86_64
@@ -42,7 +42,7 @@ spec:
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:
-    serviceAccountName: build-pipeline-osc-podvm-payload
+    serviceAccountName: build-pipeline-osc-podvm-payload-v1-12
   taskRunSpecs:
   - pipelineTaskName: sast-snyk-check
     stepSpecs:


### PR DESCRIPTION
For the pipeline to trigger on the new branch, we need the tekton files to be updated so that they reference the new Konflux object names, branch name, and quay.io image location.