### PR TITLE
release: update CPE version to 1.130

### DIFF
--- a/podvm-payload/Dockerfile
+++ b/podvm-payload/Dockerfile
@@ -164,7 +164,7 @@ COPY .git/modules/podvm-payload/kata-containers/HEAD /kata-vcs-ref
 
 # Red Hat labels
 LABEL name="openshift-sandboxed-containers/osc-podvm-payload-rhel9" \
-cpe="cpe:/a:redhat:confidential_compute_attestation:1.13::el9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9" \
 version="1.13" \
 com.redhat.component="osc-podvm-payload-container" \
 summary="Container image containing podvm artefacts that is required for creating Pod VM images" \

--- a/src/cloud-api-adaptor/Dockerfile.openshift
+++ b/src/cloud-api-adaptor/Dockerfile.openshift
@@ -114,7 +114,7 @@ COPY --from=builder /work/cloud-api-adaptor/cloud-api-adaptor /work/cloud-api-ad
 
 # Red Hat labels
 LABEL name="openshift-sandboxed-containers/osc-cloud-api-adaptor-rhel9" \
-cpe="cpe:/a:redhat:confidential_compute_attestation:1.13::el9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9" \
 version="1.13" \
 com.redhat.component="osc-cloud-api-adaptor-container" \
 summary="osc-cloud-api-adaptor provides the ability to create Kata PODs using cloud provider APIs" \

--- a/src/webhook/Dockerfile
+++ b/src/webhook/Dockerfile
@@ -28,7 +28,7 @@ USER 65532:65532
 
 # Red Hat labels
 LABEL name="openshift-sandboxed-containers/osc-cloud-api-adaptor-webhook-rhel9" \
-cpe="cpe:/a:redhat:confidential_compute_attestation:1.13::el9" \
+cpe="cpe:/a:redhat:confidential_compute_attestation:1.130::el9" \
 version="1.13" \
 com.redhat.component="osc-cloud-api-adaptor-webhook-container" \
 summary="This mutating webhook modifies a POD spec using specific runtimeclass to remove all resources entries and replace it with peer-pod extended resource." \


### PR DESCRIPTION
ProdSec product-definitions registers the OSC 1.13 stream with CPE version 1.130. Update all Dockerfiles to match.