### PR TITLE
konflux: add a tag to our images that mentions the PR it built from

### DIFF
--- a/.tekton/build-pipeline.yaml
+++ b/.tekton/build-pipeline.yaml
@@ -94,6 +94,10 @@ spec:
     type: string
     default: .
     description: Target directories to scan with SAST tools. Multiple values should be separated with commas.
+  - name: additional-tags
+    type: array
+    default: []
+    description: Additional tags to apply to the built image (e.g. pr-<number> for PR builds)
   results:
   - description: ""
     name: IMAGE_URL
@@ -519,6 +523,9 @@ spec:
       value: $(tasks.build-image-index.results.IMAGE_URL)
     - name: IMAGE_DIGEST
       value: $(tasks.build-image-index.results.IMAGE_DIGEST)
+    - name: ADDITIONAL_TAGS
+      value:
+      - $(params.additional-tags[*])
     runAfter:
     - build-image-index
     taskRef:

--- a/.tekton/osc-caa-pull-request.yaml
+++ b/.tekton/osc-caa-pull-request.yaml
@@ -44,6 +44,10 @@ spec:
     value: '[{"type": "rpm", "path": "./src/cloud-api-adaptor/"}, {"type": "gomod", "path": "./src/cloud-api-adaptor"}]'
   - name: build-args-file
     value: '.tekton/caa-build-args.env'
+  - name: additional-tags
+    value:
+    - pr-{{pull_request_number}}
+    - pullreq-{{pull_request_number}}-{{revision}}
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-caa-webhook-pull-request.yaml
+++ b/.tekton/osc-caa-webhook-pull-request.yaml
@@ -42,6 +42,10 @@ spec:
     value: src/webhook
   - name: prefetch-input
     value: '{"type": "gomod", "path": "./src/webhook/"}'
+  - name: additional-tags
+    value:
+    - pr-{{pull_request_number}}
+    - pullreq-{{pull_request_number}}-{{revision}}
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:

--- a/.tekton/osc-podvm-payload-pull-request.yaml
+++ b/.tekton/osc-podvm-payload-pull-request.yaml
@@ -41,6 +41,10 @@ spec:
     value: podvm-payload/Dockerfile
   - name: prefetch-input
     value: '[{"type": "rpm", "path": "./podvm-payload/"}, {"type": "gomod", "path": "./src/cloud-api-adaptor/"}, {"type": "cargo", "path": "./podvm-payload/kata-containers/"}, {"type": "cargo", "path": "./podvm-payload/guest-components/"}, {"type": "cargo", "path": "./podvm-payload/guest-components/attestation-agent/nvidia-attestation-sdk/nv-attestation-sdk-cpp/vendor/regorus/bindings/ffi/"}]'
+  - name: additional-tags
+    value:
+    - pr-{{pull_request_number}}
+    - pullreq-{{pull_request_number}}-{{revision}}
   pipelineRef:
     name: build-pipeline
   taskRunTemplate:


### PR DESCRIPTION
Identifying images on quay is hard. This commit makes sure we tag our image with the PR number it was built from. This should make it easier to identify what image we can use for testing a build before we merge the PR.

We create 2 tags, for different purposes:
- pr-[PR number]: this is overriden on each build, and tags the latest build
- pullreq-[PR number]-[head commit SHA]: provides an easy to find tag, while keeping an history of builds.