### PR TITLE
osc-podvm-payload: update submodules to use 1.13 release branch

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,8 +1,8 @@
 [submodule "podvm-payload/kata-containers"]
 	path = podvm-payload/kata-containers
 	url = https://github.com/openshift/kata-containers/
-	branch = osc-release
+	branch = osc-release-v1.13
 [submodule "podvm-payload/guest-components"]
 	path = podvm-payload/guest-components
 	url = https://github.com/openshift/confidential-containers-guest-components/
-	branch = osc-release
+	branch = osc-release-v1.13


### PR DESCRIPTION
Fixes: [KATA-5601](https://redhat.atlassian.net/browse/KATA-5601)